### PR TITLE
Fix the auth callback URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Make sure `$GOPATH/bin` is in your `PATH` for this to work.
 
 To set up the app, run `spc config` to generate a skeleton config file at `~/.config/spc/config.yaml` or `.config/spc/config.yaml` in your user directory on Windows.
 
-Next, head to <http://developer.spotify.com/dashboard> to create a new Spotify app. Make sure to set a callback URL for `http://localhost:8888/callback`. Paste the ClientID and ClientSecret in the newly created config file as noted in the file. **Make sure the ClientSecret is base64 encoded.**
+Next, head to <http://developer.spotify.com/dashboard> to create a new Spotify app. Make sure to set the callback URL to `http://127.0.0.1:8888/callback` in the Spotify app settings. Paste the ClientID and ClientSecret in the newly created config file as noted in the file. **Make sure the ClientSecret is base64 encoded.**
 
 You can now run `spc auth` to start the OAuth2 flow, which will have you grant the Spotify app you created, and thus `spc`, the correct API permissions.
 

--- a/cmd/helper/authHelp.go
+++ b/cmd/helper/authHelp.go
@@ -30,33 +30,33 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/zalando/go-keyring"
 	"github.com/zmb3/spotify/v2"
-	"github.com/zmb3/spotify/v2/auth"
+	spotifyauth "github.com/zmb3/spotify/v2/auth"
 	"golang.org/x/oauth2"
 )
 
-const redirectURI = "http://localhost:8888/callback"
+const redirectURI = "http://127.0.0.1:8888/callback"
 
 var (
 	authenticator *spotifyauth.Authenticator
-	ch       = make(chan *spotify.Client)
-	clientID string
-	secret   string
-	state    = "ringdingthing"
+	ch            = make(chan *spotify.Client)
+	clientID      string
+	secret        string
+	state         = "ringdingthing"
 )
 
 func initAuthenticator(clientID string, secret string) {
-    authenticator = spotifyauth.New(
-        spotifyauth.WithRedirectURL(redirectURI),
-        spotifyauth.WithClientID(clientID),
-        spotifyauth.WithClientSecret(secret),
-        spotifyauth.WithScopes(
-            spotifyauth.ScopeStreaming,
-            spotifyauth.ScopeUserModifyPlaybackState,
-            spotifyauth.ScopeUserReadPlaybackState,
-            spotifyauth.ScopePlaylistModifyPrivate,
-            spotifyauth.ScopePlaylistModifyPublic,
-        ),
-    )
+	authenticator = spotifyauth.New(
+		spotifyauth.WithRedirectURL(redirectURI),
+		spotifyauth.WithClientID(clientID),
+		spotifyauth.WithClientSecret(secret),
+		spotifyauth.WithScopes(
+			spotifyauth.ScopeStreaming,
+			spotifyauth.ScopeUserModifyPlaybackState,
+			spotifyauth.ScopeUserReadPlaybackState,
+			spotifyauth.ScopePlaylistModifyPrivate,
+			spotifyauth.ScopePlaylistModifyPublic,
+		),
+	)
 }
 
 func completeAuth(w http.ResponseWriter, r *http.Request) {

--- a/docs/spc_auth.md
+++ b/docs/spc_auth.md
@@ -4,8 +4,10 @@ Authenticates with Spotify
 
 ### Synopsis
 
-Authenticates with Spotify by printout out a login link, which will then save your access token to the config file.
-Use this command after the initial login to refresh your access token
+Authenticates with Spotify by printing a login link, which will then save your access token to the config file.
+Use this command after the initial login to refresh your access token.
+
+Before running this command, make sure your Spotify app's callback URL is set to `http://127.0.0.1:8888/callback` in the Spotify developer dashboard.
 
 ```
 spc auth [flags]


### PR DESCRIPTION
Sets the callback URL to 127.0.0.1. This is due to a change on Spotify's side where `localhost` is no longer an allowed insecure callback host, we must instead use the IP for `localhost`